### PR TITLE
Don't panic() on bad acks

### DIFF
--- a/proximo-server/nats-streaming.go
+++ b/proximo-server/nats-streaming.go
@@ -40,11 +40,11 @@ func (h *natsStreamingHandler) HandleConsume(ctx context.Context, consumer, topi
 				case cr := <-confirmRequest:
 					seq, err := strconv.ParseUint(cr.MsgID, 10, 64)
 					if err != nil {
-						ackErrors <- fmt.Errorf("ailed to parse message sequence '%v' TODO: change this from a panic", cr.MsgID)
+						ackErrors <- fmt.Errorf("failed to parse message sequence '%v'", cr.MsgID)
 						return
 					}
 					if seq != msg.Sequence {
-						ackErrors <- fmt.Errorf("unexpected message sequence. was %v but wanted %v. TODO: change this from a panic", seq, msg.Sequence)
+						ackErrors <- fmt.Errorf("unexpected message sequence. was %v but wanted %v.", seq, msg.Sequence)
 						return
 					}
 					msg.Ack()

--- a/proximo-server/nats-streaming.go
+++ b/proximo-server/nats-streaming.go
@@ -18,8 +18,6 @@ type natsStreamingHandler struct {
 
 func (h *natsStreamingHandler) HandleConsume(ctx context.Context, consumer, topic string, forClient chan<- *Message, confirmRequest <-chan *Confirmation) error {
 
-	ctx, cancel := context.WithCancel(ctx)
-
 	conn, err := stan.Connect(h.clusterID, consumer+generateID(), stan.NatsURL(h.url))
 	if err != nil {
 		return err
@@ -86,7 +84,6 @@ func (h *natsStreamingHandler) HandleConsume(ctx context.Context, consumer, topi
 		wg.Wait()
 		return conn.Close()
 	case err := <-ackErrors:
-		cancel()
 		wg.Wait()
 		conn.Close()
 		return err


### PR DESCRIPTION
When getting bad acks from the consumer, instead of a panic (which means
proximo exits) we instead exit the consume function with an appropriate
error message.