### PR TITLE
Deal with messages channel being closed

### DIFF
--- a/proximo-server/kafka.go
+++ b/proximo-server/kafka.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -65,7 +66,10 @@ func (h *kafkaHandler) consume(ctx context.Context, c *cluster.Consumer, forClie
 
 	for {
 		select {
-		case msg := <-c.Messages():
+		case msg, ok := <-c.Messages():
+			if !ok {
+				return errors.New("kafka message channel was closed")
+			}
 			confirmID := fmt.Sprintf("%d-%d", msg.Offset, msg.Partition)
 			select {
 			case forClient <- &Message{Data: msg.Value, Id: confirmID}:


### PR DESCRIPTION
If the channel or sarama messages is closed, we should exit the consume
loop with a reasonable error, instead of panicing the proximo server.