### PR TITLE
Improve kafka consumer throughput

### DIFF
--- a/proximo-server/kafka.go
+++ b/proximo-server/kafka.go
@@ -46,14 +46,24 @@ func (h *kafkaHandler) HandleConsume(ctx context.Context, conf consumerConfig, f
 		}
 	}()
 
+	var toConfirm []string
 	for {
 		select {
+		case tc := <-toConfirmIds:
+			toConfirm = append(toConfirm, tc)
 		case cr := <-confirmRequest:
-			err := h.confirm(ctx, c, cr.GetMsgID(), toConfirmIds, conf.topic)
+			if len(toConfirm) < 1 {
+				return errInvalidConfirm
+			}
+			if toConfirm[0] != cr.GetMsgID() {
+				return errInvalidConfirm
+			}
+			err := h.confirm(ctx, c, cr.GetMsgID(), conf.topic)
 			if err != nil {
 				return err
 			}
 			h.counters.SourcedMessagesCounter.WithLabelValues(conf.topic).Inc()
+			toConfirm = toConfirm[1:]
 		case <-ctx.Done():
 			return nil
 		case err := <-errors:
@@ -75,13 +85,13 @@ func (h *kafkaHandler) consume(ctx context.Context, c *cluster.Consumer, forClie
 			}
 			confirmID := fmt.Sprintf("%d-%d", msg.Offset, msg.Partition)
 			select {
-			case forClient <- &Message{Data: msg.Value, Id: confirmID}:
+			case toConfirmID <- confirmID:
 			case <-ctx.Done():
 				grpclog.Println("context is done")
 				return c.Close()
 			}
 			select {
-			case toConfirmID <- confirmID:
+			case forClient <- &Message{Data: msg.Value, Id: confirmID}:
 			case <-ctx.Done():
 				grpclog.Println("context is done")
 				return c.Close()
@@ -96,24 +106,17 @@ func (h *kafkaHandler) consume(ctx context.Context, c *cluster.Consumer, forClie
 	}
 }
 
-func (h *kafkaHandler) confirm(ctx context.Context, c *cluster.Consumer, id string, toConfirmID chan string, topic string) error {
-	select {
-	case cid := <-toConfirmID:
-		if cid != id {
-			return errInvalidConfirm
-		}
-		spl := strings.Split(cid, "-")
-		o, err := strconv.ParseInt(spl[0], 10, 64)
-		if err != nil {
-			return fmt.Errorf("error parsing message id '%s' : %s", id, err.Error())
-		}
-		p, err := strconv.ParseInt(spl[1], 10, 32)
-		if err != nil {
-			return fmt.Errorf("error parsing message id '%s' : %s", id, err.Error())
-		}
-		c.MarkPartitionOffset(topic, int32(p), o, "")
-	case <-ctx.Done():
+func (h *kafkaHandler) confirm(ctx context.Context, c *cluster.Consumer, id string, topic string) error {
+	spl := strings.Split(id, "-")
+	o, err := strconv.ParseInt(spl[0], 10, 64)
+	if err != nil {
+		return fmt.Errorf("error parsing message id '%s' : %s", id, err.Error())
 	}
+	p, err := strconv.ParseInt(spl[1], 10, 32)
+	if err != nil {
+		return fmt.Errorf("error parsing message id '%s' : %s", id, err.Error())
+	}
+	c.MarkPartitionOffset(topic, int32(p), o, "")
 	return nil
 }
 


### PR DESCRIPTION
Kafka consumer throughput was poor because, despite handling message
reading and ack sending on different goroutines, these were effectively
doing one message at a time because the message sending goroutine could
not send to the toConfirmIds channel until the ack was being sent.

This splits things so that we don't block in this way any more and
instead keep a slice of messages needing to be acked.

(Note that this is unfortunately cherry picked from upstream instead of merged, due to other as-yet unmerged changes that should be addressed in future)